### PR TITLE
editorial header update

### DIFF
--- a/public/spec/20190303/index.html
+++ b/public/spec/20190303/index.html
@@ -503,12 +503,17 @@ body {
       <dl>
         <dt>This version:</dt>
         <dd>
+          <a class="u-url" href="https://indieauth.spec.indieweb.org/20190303/">https://indieauth.spec.indieweb.org/20190303/</a>
+        </dd>
+
+        <dt>Latest published version:</dt>
+        <dd>
           <a class="u-url" href="https://indieauth.spec.indieweb.org/">https://indieauth.spec.indieweb.org/</a>
         </dd>
 
         <dt>Previous version:</dt>
         <dd>
-          <a href="https://www.w3.org/TR/indieauth/">https://www.w3.org/TR/indieauth/</a>
+          <a href="https://www.w3.org/TR/2018/NOTE-indieauth-20180123/">https://www.w3.org/TR/2018/NOTE-indieauth-20180123/</a>
         </dd>
 
         <dt>Test suite:</dt><dd><a href="https://indieauth.rocks/">https://indieauth.rocks/</a></dd>


### PR DESCRIPTION
fix "This Version" link, add Latest published version, and fix Previous version to link to W3C permalink. needs more edits re: W3C logo/(c) but this is an incremental improvement.