### PR TITLE
heading editorial, latest version on spec.indieweb

### DIFF
--- a/public/spec/index.html
+++ b/public/spec/index.html
@@ -649,14 +649,15 @@ body {
       <a class="logo" href="https://www.w3.org/"><img alt="W3C" width="72" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C"></a> <h1 id="title" class="title p-name">IndieAuth</h1>
       
       <h2>
-        W3C Living Standard
+        Living Standard
         <time class="dt-published" datetime="2020-01-25">25 January 2020</time>
       </h2>
       <dl>
         <dt>This version:</dt><dd>
                 <a class="u-url" href="https://indieauth.spec.indieweb.org/">https://indieauth.spec.indieweb.org/</a>
-              </dd><dt>Latest published version:</dt><dd>
-                <a href="https://www.w3.org/TR/indieauth/">https://www.w3.org/TR/indieauth/</a>
+                <!-- consider archiving and linking to "This version" at https://indieauth.spec.indieweb.org/20200125/ -->
+              </dd><dt>Latest version:</dt><dd>
+                <a href="https://indieauth.spec.indieweb.org/">https://indieauth.spec.indieweb.org/</a>
               </dd>
         
         <dt>Test suite:</dt><dd><a href="https://indieauth.rocks/">https://indieauth.rocks/</a></dd>


### PR DESCRIPTION
remove "W3C" from "Living Standard", link latest version as on spec.indieweb, note in comment about "this version" could link to a /20200125/ archive.