### PR TITLE
use snapshot for dated version

### DIFF
--- a/public/spec/20190303/index.html
+++ b/public/spec/20190303/index.html
@@ -487,7 +487,7 @@ body {
     }
   },
   "publishISODate": "2019-03-03T00:00:00.000Z",
-  "generatedSubtitle": "Living Standard - Last Updated 03 March 2019"
+  "generatedSubtitle": "Living Standard Snapshot - Last Updated 03 March 2019"
 }</script><meta name="description" content="IndieAuth is an identity layer on top of OAuth 2.0 [RFC6749], primarily used to obtain
         an OAuth 2.0 Bearer Token [RFC6750] for use by [Micropub] clients. End-Users
         and Clients are all represented by URLs. IndieAuth enables Clients to
@@ -497,7 +497,7 @@ body {
       <a href="https://www.w3.org/" class="logo"><img alt="W3C" width="72" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C"></a> <h1 id="title" class="title p-name">IndieAuth</h1>
 
       <h2>
-        Living Standard
+        Living Standard Snapshot
         <time class="dt-published" datetime="2019-03-03">03 March 2019</time>
       </h2>
       <dl>


### PR DESCRIPTION
WHATWG uses the term "snapshot" for specific dated versions of a living standard so we should too