### PR TITLE
Editorial: "latest living" is redundant

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,5 +2,5 @@
 
 This repository is for the IndieAuth specification, as well as related documentation that lives at [indieauth.net](https://indieauth.net).
 
-* [Latest Living Standard](https://indieauth.spec.indieweb.org/)
+* [IndieAuth Living Standard](https://indieauth.spec.indieweb.org/)
 * [Issues](https://github.com/aaronpk/indieauth.net/issues)


### PR DESCRIPTION
and improve link text so it reinforces what people learn and find they are looking for