### PR TITLE
new authorization server confirmation section

### DIFF
--- a/public/source/index.php
+++ b/public/source/index.php
@@ -592,6 +592,90 @@ Content-Type: application/json
 
       </section>
 
+      <section>
+        <h3>Authorization Server Confirmation</h3>
+        <span id="differing-user-profile-urls"></span><!-- preserve old fragment identifier -->
+
+        <p>Clients will initially prompt the user to enter a URL in order to discover the necessary endpoints to perform authentication or authorization. However, there may be differences between the URL that the user initially enters and the final resulting profile URL as returned by the authorization server. The differences may be anything from a differing scheme (http vs https), to even a URL on a different domain.</p>
+
+        <p>Upon receiving the <code>me</code> URL in the response from the authorization server (either in the <a href="#profile-url-response">profile URL response</a> or <a href="#access-token-response">access token response</a>) the client MUST verify the authorization server is authorized to make claims about the profile URL returned by checking that either of the following is true:</p>
+
+        <ul>
+          <li>checking the returned <code>me</code> URL to see if it is an exact match of any of the URLs encountered during the <a href="#discovery-by-clients">initial endpoint discovery</a>, either from a possible redirect chain or as the final value, OR</li>
+          <li>verifying that the returned profile URL declares the same <code>authorization_endpoint</code> as the initially-discovered authorization endpoint by redoing <a href="#discovery-by-clients">endpoint discovery</a> on the <code>me</code> value.</li>
+        </ul>
+
+        <p>These steps ensure that an authorization endpoint is not able to issue valid responses for arbitrary profile URLs, and that users on a shared domain cannot forge authorization on behalf of other users of that domain.</p>
+
+
+        <h4>Examples</h4>
+
+        <p>The following are some non-normative examples of real-world scenarios in which the initial user-entered URL may be different from the final resulting profile URL returned by the authorization server.</p>
+
+        <h5>Basic Redirect</h5>
+
+        <p>The basic redirect example covers cases such as:
+          <ul>
+            <li>entering a domain with a www prefix and resolving it to the main domain</li>
+            <li>entering a URL with no scheme or with http and resolving it to an https URL</li>
+            <li>entering a short domain and resolving it to a different longer domain</li>
+          </ul>
+        </p>
+
+        <ol>
+          <li>The user enters <code>www.example.com</code> into the client</li>
+          <li>The client applies the steps from URL canoncalization to turn it into a URL: <code>http://www.example.com/</code></li>
+          <li>The client makes a GET request to <code>http://www.example.com/</code></li>
+          <li>The server returns a 301 redirect to <code>https://example.com/</code></li>
+          <li>The client makes a GET request to <code>https://example.com/</code> and finds the authorization endpoint</li>
+          <li>The client does the IndieAuth flow with that authorization endpoint. This results in the profile URL response with a <code>me</code> value of <code>https://example.com/</code> as the canonical Profile URL.</li>
+          <li>The client sees that the canonical Profile URL matches the URL that the authorization endpoint was discovered at, and accepts the value <code>https://example.com/</code></li>
+        </ol>
+
+        <h5>Service Domain to Subdomain</h5>
+
+        <ol>
+          <li>The user enters <code>example.com</code> into the client</li>
+          <li>The client applies the steps from URL canoncalization to turn it into a URL: <code>http://example.com/</code></li>
+          <li>The client makes a GET request to <code>http://example.com/</code></li>
+          <li>The server returns a 301 redirect to <code>https://example.com/</code></li>
+          <li>The client makes a GET request to <code>https://example.com/</code> and finds the authorization endpoint, <code>https://login.example.com</code></li>
+          <li>The client does the IndieAuth flow with <code>https://login.example.com</code>. This results in the profile URL response with a <code>me</code> value of <code>https://username.example.com/</code> as the canonical Profile URL.</li>
+          <li>This is the first time the client has seen this URL, so must verify the relationship between this subdomain and the authorization server. It fetches <code>https://username.example.com/</code> and finds the same authorization endpoint <code>https://login.example.com</code></li>
+          <li>The client accepts the <code>me</code> value of <code>https://username.example.com/</code></li>
+        </ol>
+
+        <h5>Service Domain to Path</h5>
+
+        <ol>
+          <li>The user enters <code>example.com</code> into the client</li>
+          <li>The client applies the steps from URL canoncalization to turn it into a URL: <code>http://example.com/</code></li>
+          <li>The client makes a GET request to <code>http://example.com/</code></li>
+          <li>The server returns a 301 redirect to <code>https://example.com/</code></li>
+          <li>The client makes a GET request to <code>https://example.com/</code> and finds the authorization endpoint, <code>https://login.example.com</code></li>
+          <li>The client does the IndieAuth flow with <code>https://login.example.com</code>. This results in the profile URL response with a <code>me</code> value of <code>https://example.com/username</code> as the canonical Profile URL.</li>
+          <li>This is the first time the client has seen this URL, so must verify the relationship between this subdomain and the authorization server. It fetches <code>https://example.com/username</code> and finds the same authorization endpoint <code>https://login.example.com</code></li>
+          <li>The client accepts the <code>me</code> value of <code>https://example.com/username</code></li>
+        </ol>
+
+        <h5>Email-like Identifier</h5>
+
+        <ol>
+          <li>The user enters <code>user@example.com</code> into the client</li>
+          <li>The client applies the steps from URL canoncalization to turn it into a URL: <code>http://user@example.com/</code></li>
+          <li>The client makes a GET request to <code>http://example.com/</code> providing the HTTP Basic Auth username <code>user</code></li>
+          <li>The server returns a 301 redirect to <code>https://example.com/</code></li>
+          <li>The client makes a GET request to <code>https://example.com/</code> and finds the authorization endpoint, <code>https://login.example.com</code>
+            <ul><li>Note: Alternatively the server can advertise the authorization endpoint in the response to the <code>http://user@example.com/</code> request directly instead of needing a separate redirect</li></ul>
+          </li>
+          <li>The client does the IndieAuth flow with <code>https://login.example.com</code>, providing the user-entered <code>user@example.com</code> in the request as a hint to the server. This results in the profile URL response with a <code>me</code> value of <code>https://example.com/username</code> as the canonical Profile URL.</li>
+          <li>This is the first time the client has seen this URL, so must verify the relationship between this subdomain and the authorization server. It fetches <code>https://example.com/username</code> and finds the same authorization endpoint <code>https://login.example.com</code></li>
+          <li>The client accepts the <code>me</code> value of <code>https://example.com/username</code></li>
+        </ol>
+
+
+      </section>
+
     </section>
 
     <section class="normative">
@@ -668,24 +752,6 @@ Content-Type: application/json
       <h2>Security Considerations</h2>
 
       <p>In addition to the security considerations in OAuth 2.0 Core [[RFC6749]] and OAuth 2.0 Threat Model and Security Considerations [[RFC6819]], the additional considerations apply.</p>
-
-      <section>
-        <h3>Differing User Profile URLs</h3>
-
-        <p>Clients will initially prompt the user for their profile URL in order to discover the necessary endpoints to perform authentication or authorization. However, there may be slight differences between the URL that the user initially enters vs what the system considers the user's canonical profile URL.</p>
-
-        <p>For example, a user might enter <code>user.example.net</code> in a login interface, and the client may assume a default scheme of <code>http</code>, providing an initial profile URL of <code>http://user.example.net</code>. Once the authentication or authorization flow is complete, the response in the <code>me</code> parameter might be the canonical <code>https://user.example.net/</code>. In some cases, user profile URLs have a full path component such as <code>https://example.net/username</code>, but users may enter just <code>example.net</code> in the login interface.</p>
-
-        <p>Upon validation, the client MUST check the <code>me</code> value from the <a href="#profile-url-response">profile URL response</a> or <a href="#access-token-response">access token response</a>, and take the following validation steps:</p>
-
-        <ol>
-          <li>It MAY check the value against any URLs encountered during the <a href="#discovery-by-clients">initial endpoint discovery</a>, either from a possible redirect chain or the final value. If found, it MAY then chose to skip the next step.</li>
-          <li>It MUST verify that the canonical profile URL declares the same <code>authorization_endpoint</code> as the initially-discovered authorization endpoint by redoing <a href="#discovery-by-clients">endpoint discovery</a> on the <code>me</code> value.</li>
-        </ol>
-
-        <p>These steps ensure that an authorization endpoint is not able to issue valid responses for arbitrary profile URLs, and that users on a shared domain cannot forge authorization on behalf of other users of that domain.</p>
-
-      </section>
 
       <section>
         <h3>Preventing Phishing and Redirect Attacks</h3>

--- a/public/source/index.php
+++ b/public/source/index.php
@@ -785,7 +785,14 @@ Content-Type: application/json
       <h2>Change Log</h2>
 
       <section>
-        <h3>Changes from 09 August 2020 to this version</h3>
+        <h3>Changes from 26 September 2020 to this version</h3>
+        <ul>
+          <li>Remove same-domain requirement for entered and final profile URL by instead confirming the authorization server</li>
+        </ul>
+      </section>
+
+      <section>
+        <h3>Changes from 09 August 2020 to 26 September 2020</h3>
         <ul>
           <li>Make the <code>me</code> parameter optional (but recommended) in the authorization request</li>
           <li>Add the option of returning profile information in the response as well as defining profile scopes</li>


### PR DESCRIPTION
* moves the "Different Profile URLs" section from security considerations into section 5 as the final step to make it more prominent to client developers
* Renames header to "Authorization Server Confirmation"
* Rephrases a bunch of the content
* Adds several examples of cases that the initially entered profile URL may differ from the final URL