### PR TITLE
Document breaking change in Change Log.

### DIFF
--- a/public/source/index.php
+++ b/public/source/index.php
@@ -872,6 +872,7 @@ Content-Type: application/json
         <h3>Changes from 25 January 2020 to 09 August 2020</h3>
         <ul>
           <li>Use <code>response_type=code</code> and make it required, to bring it in line with OAuth 2.0</li>
+          <li>Require <code>grant_type=authorization_code</code> when redeeming the authorization code at the authorization endpoint</li>
           <li>Drop the <code>me</code> parameter from the token endpoint request</li>
           <li>Consolidate the authentication and authorization sections into a single section, describing only the difference which is the response returned.</li>
           <li>Drop the section describing communication between token endpoints and authorization endpoints as it was underused</li>

--- a/public/spec/20200809/index.html
+++ b/public/spec/20200809/index.html
@@ -809,10 +809,11 @@ Content-Type: application/json
         <h3 id="c-1-changes-from-25-january-2020-to-this-version"><bdi class="secno">C.1 </bdi>Changes from 25 January 2020 to this version<a class="self-link" aria-label="§" href="#changes-from-25-january-2020-to-this-version"></a></h3>
         <ul>
           <li id="changes-from-25-january-2020-to-this-version-li-1">Use <code>response_type=code</code> and make it required, to bring it in line with OAuth 2.0</li>
-          <li id="changes-from-25-january-2020-to-this-version-li-2">Drop the <code>me</code> parameter from the token endpoint request</li>
-          <li id="changes-from-25-january-2020-to-this-version-li-3">Consolidate the authentication and authorization sections into a single section, describing only the difference which is the response returned.</li>
-          <li id="changes-from-25-january-2020-to-this-version-li-4">Drop the section describing communication between token endpoints and authorization endpoints as it was underused</li>
-          <li id="changes-from-25-january-2020-to-this-version-li-5">Editorial changes and rearranging sections</li>
+          <li id="changes-from-25-january-2020-to-this-version-li-2">Require <code>grant_type=authorization_code</code> when redeeming the authorization code at the authorization endpoint</li>
+          <li id="changes-from-25-january-2020-to-this-version-li-3">Drop the <code>me</code> parameter from the token endpoint request</li>
+          <li id="changes-from-25-january-2020-to-this-version-li-4">Consolidate the authentication and authorization sections into a single section, describing only the difference which is the response returned.</li>
+          <li id="changes-from-25-january-2020-to-this-version-li-5">Drop the section describing communication between token endpoints and authorization endpoints as it was underused</li>
+          <li id="changes-from-25-january-2020-to-this-version-li-6">Editorial changes and rearranging sections</li>
         </ul>
       </section>
 

--- a/public/spec/20200926/index.html
+++ b/public/spec/20200926/index.html
@@ -899,10 +899,11 @@ Content-Type: application/json
         <h3 id="c-2-changes-from-25-january-2020-to-09-august-2020"><bdi class="secno">C.2 </bdi>Changes from 25 January 2020 to 09 August 2020<a class="self-link" aria-label="§" href="#changes-from-25-january-2020-to-09-august-2020"></a></h3>
         <ul>
           <li id="changes-from-25-january-2020-to-09-august-2020-li-1">Use <code>response_type=code</code> and make it required, to bring it in line with OAuth 2.0</li>
-          <li id="changes-from-25-january-2020-to-09-august-2020-li-2">Drop the <code>me</code> parameter from the token endpoint request</li>
-          <li id="changes-from-25-january-2020-to-09-august-2020-li-3">Consolidate the authentication and authorization sections into a single section, describing only the difference which is the response returned.</li>
-          <li id="changes-from-25-january-2020-to-09-august-2020-li-4">Drop the section describing communication between token endpoints and authorization endpoints as it was underused</li>
-          <li id="changes-from-25-january-2020-to-09-august-2020-li-5">Editorial changes and rearranging sections</li>
+          <li id="changes-from-25-january-2020-to-09-august-2020-li-2">Require <code>grant_type=authorization_code</code> when redeeming the authorization code at the authorization endpoint</li>
+          <li id="changes-from-25-january-2020-to-09-august-2020-li-3">Drop the <code>me</code> parameter from the token endpoint request</li>
+          <li id="changes-from-25-january-2020-to-09-august-2020-li-4">Consolidate the authentication and authorization sections into a single section, describing only the difference which is the response returned.</li>
+          <li id="changes-from-25-january-2020-to-09-august-2020-li-5">Drop the section describing communication between token endpoints and authorization endpoints as it was underused</li>
+          <li id="changes-from-25-january-2020-to-09-august-2020-li-6">Editorial changes and rearranging sections</li>
         </ul>
       </section>
 

--- a/public/spec/index.html
+++ b/public/spec/index.html
@@ -899,10 +899,11 @@ Content-Type: application/json
         <h3 id="c-2-changes-from-25-january-2020-to-09-august-2020"><bdi class="secno">C.2 </bdi>Changes from 25 January 2020 to 09 August 2020<a class="self-link" aria-label="§" href="#changes-from-25-january-2020-to-09-august-2020"></a></h3>
         <ul>
           <li id="changes-from-25-january-2020-to-09-august-2020-li-1">Use <code>response_type=code</code> and make it required, to bring it in line with OAuth 2.0</li>
-          <li id="changes-from-25-january-2020-to-09-august-2020-li-2">Drop the <code>me</code> parameter from the token endpoint request</li>
-          <li id="changes-from-25-january-2020-to-09-august-2020-li-3">Consolidate the authentication and authorization sections into a single section, describing only the difference which is the response returned.</li>
-          <li id="changes-from-25-january-2020-to-09-august-2020-li-4">Drop the section describing communication between token endpoints and authorization endpoints as it was underused</li>
-          <li id="changes-from-25-january-2020-to-09-august-2020-li-5">Editorial changes and rearranging sections</li>
+          <li id="changes-from-25-january-2020-to-09-august-2020-li-2">Require <code>grant_type=authorization_code</code> when redeeming the authorization code at the authorization endpoint</li>
+          <li id="changes-from-25-january-2020-to-09-august-2020-li-3">Drop the <code>me</code> parameter from the token endpoint request</li>
+          <li id="changes-from-25-january-2020-to-09-august-2020-li-4">Consolidate the authentication and authorization sections into a single section, describing only the difference which is the response returned.</li>
+          <li id="changes-from-25-january-2020-to-09-august-2020-li-5">Drop the section describing communication between token endpoints and authorization endpoints as it was underused</li>
+          <li id="changes-from-25-january-2020-to-09-august-2020-li-6">Editorial changes and rearranging sections</li>
         </ul>
       </section>
 


### PR DESCRIPTION
When the sections for redeeming the authorization code at the authorization endpoint and token endpoint were merged together, we defaulted to letting both use the same request. This is a breaking change. Previous to the August 9 update, there was no need to specify `grant_type` when redeeming at the authorization endpoint.

This ads it to the change log: on the current spec, in the current draft, and in the previous snapshots that should have listed it.

I put it as the second item in the change log, because I thought it read better that way. This does mean all the list IDs get shifted. Does this really matter for individual change log items? If we think it does, we will have to move it to the end of the list instead.

Fixes #61.