### PR TITLE
Fix: Correct broken links for GitHub

### DIFF
--- a/public/note/index.html
+++ b/public/note/index.html
@@ -349,7 +349,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
         },
         {
           "value": "Commits",
-          "href": "https://github.com/indieweb/indieauth/commits/master"
+          "href": "https://github.com/indieweb/indieauth/commits/main"
         }
       ]
     }
@@ -451,7 +451,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
                     </a>
                   </dd>
                   <dd>
-                    <a href="https://github.com/indieweb/indieauth/commits/master">
+                    <a href="https://github.com/indieweb/indieauth/commits/main">
                       Commits
                     </a>
                   </dd>

--- a/public/source/index.php
+++ b/public/source/index.php
@@ -43,7 +43,7 @@
               },
               {
                 value: 'Commits',
-                href: 'https://github.com/indieweb/indieauth/commits/master'
+                href: 'https://github.com/indieweb/indieauth/commits/main'
               }
             ]
           }],

--- a/public/spec/20190303/index.html
+++ b/public/spec/20190303/index.html
@@ -419,7 +419,7 @@ body {
         },
         {
           "value": "Commits",
-          "href": "https://github.com/indieweb/indieauth/commits/master"
+          "href": "https://github.com/indieweb/indieauth/commits/main"
         }
       ]
     }
@@ -531,7 +531,7 @@ body {
     </dd><dd>
       <a href="https://github.com/indieweb/indieauth/issues">Issues</a>
     </dd><dd>
-      <a href="https://github.com/indieweb/indieauth/commits/master">Commits</a>
+      <a href="https://github.com/indieweb/indieauth/commits/main">Commits</a>
     </dd>
       </dl>
       <p>

--- a/public/spec/20200125/index.html
+++ b/public/spec/20200125/index.html
@@ -568,7 +568,7 @@ var[data-type]:hover::before {
         },
         {
           "value": "Commits",
-          "href": "https://github.com/indieweb/indieauth/commits/master"
+          "href": "https://github.com/indieweb/indieauth/commits/main"
         }
       ]
     }
@@ -676,7 +676,7 @@ body {
     </dd><dd>
       <a href="https://github.com/indieweb/indieauth/issues">Issues</a>
     </dd><dd>
-      <a href="https://github.com/indieweb/indieauth/commits/master">Commits</a>
+      <a href="https://github.com/indieweb/indieauth/commits/main">Commits</a>
     </dd>
       </dl>
       <p>

--- a/public/spec/20200809/index.html
+++ b/public/spec/20200809/index.html
@@ -53,7 +53,7 @@
         },
         {
           "value": "Commits",
-          "href": "https://github.com/indieweb/indieauth/commits/master"
+          "href": "https://github.com/indieweb/indieauth/commits/main"
         }
       ]
     }
@@ -145,7 +145,7 @@
   </dd><dd>
     <a href="https://github.com/indieweb/indieauth/issues">Issues</a>
   </dd><dd>
-    <a href="https://github.com/indieweb/indieauth/commits/master">Commits</a>
+    <a href="https://github.com/indieweb/indieauth/commits/main">Commits</a>
   </dd>
     </dl>
     <p>

--- a/public/spec/20200926/index.html
+++ b/public/spec/20200926/index.html
@@ -53,7 +53,7 @@
         },
         {
           "value": "Commits",
-          "href": "https://github.com/indieweb/indieauth/commits/master"
+          "href": "https://github.com/indieweb/indieauth/commits/main"
         }
       ]
     }
@@ -145,7 +145,7 @@
   </dd><dd>
     <a href="https://github.com/indieweb/indieauth/issues">Issues</a>
   </dd><dd>
-    <a href="https://github.com/indieweb/indieauth/commits/master">Commits</a>
+    <a href="https://github.com/indieweb/indieauth/commits/main">Commits</a>
   </dd>
     </dl>
     <p>

--- a/public/spec/20201126/index.html
+++ b/public/spec/20201126/index.html
@@ -53,7 +53,7 @@
         },
         {
           "value": "Commits",
-          "href": "https://github.com/indieweb/indieauth/commits/master"
+          "href": "https://github.com/indieweb/indieauth/commits/main"
         }
       ]
     }
@@ -145,7 +145,7 @@
   </dd><dd>
     <a href="https://github.com/indieweb/indieauth/issues">Issues</a>
   </dd><dd>
-    <a href="https://github.com/indieweb/indieauth/commits/master">Commits</a>
+    <a href="https://github.com/indieweb/indieauth/commits/main">Commits</a>
   </dd>
     </dl>
     <p>

--- a/public/spec/index.html
+++ b/public/spec/index.html
@@ -53,7 +53,7 @@
         },
         {
           "value": "Commits",
-          "href": "https://github.com/indieweb/indieauth/commits/master"
+          "href": "https://github.com/indieweb/indieauth/commits/main"
         }
       ]
     }
@@ -145,7 +145,7 @@
   </dd><dd>
     <a href="https://github.com/indieweb/indieauth/issues">Issues</a>
   </dd><dd>
-    <a href="https://github.com/indieweb/indieauth/commits/master">Commits</a>
+    <a href="https://github.com/indieweb/indieauth/commits/main">Commits</a>
   </dd>
     </dl>
     <p>


### PR DESCRIPTION
Since we moved from `master` branch terminology to `main`, we've got a
number of broken links that would be good to correct, even for previous
versions of the spec.