### PR TITLE
Token Introspection

### DIFF
--- a/public/source/index.php
+++ b/public/source/index.php
@@ -744,12 +744,13 @@ Content-Type: application/json
         <li>The introspection response MUST include an additional parameter, <code>me</code>.</li>
       </ul>
 	<p>Note that the request to the endpoint will not contain any user-identifying information, so the resource server (e.g. Micropub endpoint) will need to know via out-of-band methods which token endpoint is in use.</p>
-	<p>The resource server SHOULD make a POST request to the token endpoint containing the Bearer token in the <code>token</code> parameter, which will generate a token verification response.</p>
+	<p>The resource server SHOULD make a POST request to the token endpoint containing the Bearer token in the <code>token</code> parameter, which will generate a token verification response. The endpoint MUST also require a HTTP Authorization header with a separate OAuth 2.0 access token to allow the call to this endpoint. If the token does not contain sufficient privileges or is otherwise invalid for the request, the authorization server MUST respond with an HTTP 401 code.</p>
 
           <pre class="example nohighlight"><?= htmlspecialchars(
   'POST https://example.org/token
   Content-type: application/x-www-form-urlencoded
   Accept: application/json
+  Authorization: Bearer xxxxxxxx
 
   token=xxxxxxxx
   ') ?></pre>
@@ -761,7 +762,7 @@ Content-Type: application/json
 
         <ul>
 	  <li><code>active</code> - (required) Boolean indicator of whether or not the presented token is currently active
-          <li><code>me</code> - The profile URL of the user corresponding to this token</li>
+          <li><code>me</code> - (required) The profile URL of the user corresponding to this token</li>
           <li><code>client_id</code> - The client ID associated with this token</li>
           <li><code>scope</code> - A space-separated list of scopes associated with this token</li>
 	  <li><code>exp</code> - (optional) Integer timestamp, measured in the number of seconds since January 1 1970 UTC, indicating when this token will expire</li>

--- a/public/source/index.php
+++ b/public/source/index.php
@@ -744,7 +744,7 @@ Content-Type: application/json
         <li>The introspection response MUST include an additional parameter, <code>me</code>.</li>
       </ul>
 	<p>Note that the request to the endpoint will not contain any user-identifying information, so the resource server (e.g. Micropub endpoint) will need to know via out-of-band methods which token endpoint is in use.</p>
-	<p>The resource server SHOULD make a POST request to the token endpoint containing the bearer token in a 'token' parameter, which will generate a token verification response.</p>
+	<p>The resource server SHOULD make a POST request to the token endpoint containing the Bearer token in the <code>token</code> parameter, which will generate a token verification response. The introspection endpoint MAY accept other OPTIONAL parameters to provide further context to the query.</p>
 
           <pre class="example nohighlight"><?= htmlspecialchars(
   'POST https://example.org/token

--- a/public/source/index.php
+++ b/public/source/index.php
@@ -271,6 +271,8 @@
               <li><code>issuer</code> - The server's issuer identifier. The issuer identifier is a URL that uses the "https" scheme and has no query or fragment components. The identifier MUST be a prefix of the <code>indieauth-metadata</code> URL. e.g. for an <code>indieauth-metadata</code> endpoint <code>https://example.com/.well-known/oauth-authorization-server</code>, the issuer URL could be <code>https://example.com/</code>, or for a metadata URL of <code>https://example.com/wp-json/indieauth/1.0/metadata</code>, the issuer URL could be <code>https://example.com/wp-json/indieauth/1.0</code></li>
               <li><code>authorization_endpoint</code> - The Authorization Endpoint</li>
               <li><code>token_endpoint</code> - The Token Endpoint</li>
+	      <li><code>introspection_endpoint</code> - The Introspection Endpoint</li>
+	      <li><code>introspection_endpoint_auth_methods_supported</code> (optional) - SON array containing a list of client authentication methods supported by this introspection endpoint.
               <li><code>scopes_supported</code> (recommended) - JSON array containing scope values supported by the IndieAuth server. Servers MAY choose not to advertise some supported scope values even when this parameter is used.</li>
               <li><code>response_types_supported</code> (optional) - JSON array containing the response_type values supported. This differs from [RFC8414] in that this parameter is OPTIONAL and that, if omitted, the default is <code>code</code></li>
               <li><code>grant_types_supported</code> (optional) - JSON array containing grant type values supported. If omitted, the default value differs from [RFC8414] and is <code>authorization_code</code></li>
@@ -738,13 +740,10 @@ Content-Type: application/json
       <section>
         <h4>Access Token Verification Request</h4>
 
-        <p>If a resource server needs to verify that an access token is valid, it may do so using Token Introspection. IndieAuth extends OAuth 2.0 Token Introspection [[!RFC7662]] by defining the following:</p>
-      <ul>
-        <li>The introspection endpoint is the same as the token endpoint.</li>
-        <li>The introspection response MUST include an additional parameter, <code>me</code>.</li>
+        <p>If a resource server needs to verify that an access token is valid, it may do so using Token Introspection. IndieAuth extends OAuth 2.0 Token Introspection [[!RFC7662]] by adding that the  introspection response MUST include an additional parameter, <code>me</code>.</li>
       </ul>
 	<p>Note that the request to the endpoint will not contain any user-identifying information, so the resource server (e.g. Micropub endpoint) will need to know via out-of-band methods which token endpoint is in use.</p>
-	<p>The resource server SHOULD make a POST request to the token endpoint containing the Bearer token in the <code>token</code> parameter, which will generate a token verification response. The endpoint MUST also require a HTTP Authorization header with a separate OAuth 2.0 access token to allow the call to this endpoint. If the token does not contain sufficient privileges or is otherwise invalid for the request, the authorization server MUST respond with an HTTP 401 code.</p>
+	<p>The resource server SHOULD make a POST request to the token endpoint containing the Bearer token in the <code>token</code> parameter, which will generate a token verification response. The endpoint MUST also require some form of authorization to access this endpoint and MAY identify that in the <code>introspection_endpoint_auth_methods_supported</code> parameter of the metadata response. If the authorization is insufficient for the request, the authorization server MUST respond with an HTTP 401 code.</p>
 
           <pre class="example nohighlight"><?= htmlspecialchars(
   'POST https://example.org/token

--- a/public/source/index.php
+++ b/public/source/index.php
@@ -784,6 +784,14 @@ Content-Type: application/json
         <p>Specific implementations MAY include additional parameters as top-level JSON properties. Clients SHOULD ignore parameters they don't recognize.</p>
 
         <p>If the token is not valid, the endpoint still MUST return a 200 Response, with the only parameter being active(with its value set to "false"). The response SHOULD NOT include any additional information about an inactive token, including why the token is inactive.</p>
+
+        <pre class="example nohighlight">HTTP/1.1 200 OK
+  Content-Type: application/json
+
+  {
+  "active": "false",
+  }</pre>
+
       </section>
     </section>
 

--- a/public/source/index.php
+++ b/public/source/index.php
@@ -744,7 +744,7 @@ Content-Type: application/json
         <li>The introspection response MUST include an additional parameter, <code>me</code>.</li>
       </ul>
 	<p>Note that the request to the endpoint will not contain any user-identifying information, so the resource server (e.g. Micropub endpoint) will need to know via out-of-band methods which token endpoint is in use.</p>
-	<p>The resource server SHOULD make a POST request to the token endpoint containing the bearer token in a 'token' parameter, which will generate a token verification response. The introspection endpoint MAY accept other OPTIONAL parameters to provide further context to the query.</p>
+	<p>The resource server SHOULD make a POST request to the token endpoint containing the bearer token in a 'token' parameter, which will generate a token verification response.</p>
 
           <pre class="example nohighlight"><?= htmlspecialchars(
   'POST https://example.org/token
@@ -754,22 +754,16 @@ Content-Type: application/json
   token=xxxxxxxx
   ') ?></pre>
 
-	<p>Alternatively, the resource server MAY make a GET request to the token endpoint containing an HTTP <code>Authorization</code> header with the Bearer Token according to [[!RFC6750]], but GET may not be supported by all token endpoints.</p>
-        <pre class="example nohighlight">GET https://example.org/token
-  Authorization: Bearer xxxxxxxx
-  Accept: application/json</pre>
-      </section>
-
       <section>
         <h4>Access Token Verification Response</h4>
 
         <p>The token endpoint verifies the access token (how this verification is done is up to the implementation), and returns information about the token:</p>
 
         <ul>
+	  <li><code>active</code> - (required) Boolean indicator of whether or not the presented token is currently active
           <li><code>me</code> - The profile URL of the user corresponding to this token</li>
           <li><code>client_id</code> - The client ID associated with this token</li>
           <li><code>scope</code> - A space-separated list of scopes associated with this token</li>
-	  <li><code>active</code> - Boolean indicator of whether or not the presented token is currently active
 	  <li><code>exp</code> - (optional) Integer timestamp, measured in the number of seconds since January 1 1970 UTC, indicating when this token will expire</li>
 	  <li><code>iat</code> - (optional) Integer timestamp, measured in the number of seconds since January 1 1970 UTC, indicating when this token was originally issued</li>
         </ul>

--- a/public/source/index.php
+++ b/public/source/index.php
@@ -744,7 +744,7 @@ Content-Type: application/json
         <li>The introspection response MUST include an additional parameter, <code>me</code>.</li>
       </ul>
 	<p>Note that the request to the endpoint will not contain any user-identifying information, so the resource server (e.g. Micropub endpoint) will need to know via out-of-band methods which token endpoint is in use.</p>
-	<p>The resource server SHOULD make a POST request to the token endpoint containing the Bearer token in the <code>token</code> parameter, which will generate a token verification response. The introspection endpoint MAY accept other OPTIONAL parameters to provide further context to the query.</p>
+	<p>The resource server SHOULD make a POST request to the token endpoint containing the Bearer token in the <code>token</code> parameter, which will generate a token verification response.</p>
 
           <pre class="example nohighlight"><?= htmlspecialchars(
   'POST https://example.org/token

--- a/public/source/index.php
+++ b/public/source/index.php
@@ -272,7 +272,7 @@
               <li><code>authorization_endpoint</code> - The Authorization Endpoint</li>
               <li><code>token_endpoint</code> - The Token Endpoint</li>
 	      <li><code>introspection_endpoint</code> - The Introspection Endpoint</li>
-	      <li><code>introspection_endpoint_auth_methods_supported</code> (optional) - SON array containing a list of client authentication methods supported by this introspection endpoint.
+	      <li><code>introspection_endpoint_auth_methods_supported</code> (optional) - JSON array containing a list of client authentication methods supported by this introspection endpoint.
               <li><code>scopes_supported</code> (recommended) - JSON array containing scope values supported by the IndieAuth server. Servers MAY choose not to advertise some supported scope values even when this parameter is used.</li>
               <li><code>response_types_supported</code> (optional) - JSON array containing the response_type values supported. This differs from [RFC8414] in that this parameter is OPTIONAL and that, if omitted, the default is <code>code</code></li>
               <li><code>grant_types_supported</code> (optional) - JSON array containing grant type values supported. If omitted, the default value differs from [RFC8414] and is <code>authorization_code</code></li>
@@ -741,7 +741,6 @@ Content-Type: application/json
         <h4>Access Token Verification Request</h4>
 
         <p>If a resource server needs to verify that an access token is valid, it may do so using Token Introspection. IndieAuth extends OAuth 2.0 Token Introspection [[!RFC7662]] by adding that the  introspection response MUST include an additional parameter, <code>me</code>.</li>
-      </ul>
 	<p>Note that the request to the endpoint will not contain any user-identifying information, so the resource server (e.g. Micropub endpoint) will need to know via out-of-band methods which token endpoint is in use.</p>
 	<p>The resource server SHOULD make a POST request to the token endpoint containing the Bearer token in the <code>token</code> parameter, which will generate a token verification response. The endpoint MUST also require some form of authorization to access this endpoint and MAY identify that in the <code>introspection_endpoint_auth_methods_supported</code> parameter of the metadata response. If the authorization is insufficient for the request, the authorization server MUST respond with an HTTP 401 code.</p>
 

--- a/public/source/index.php
+++ b/public/source/index.php
@@ -738,8 +738,23 @@ Content-Type: application/json
       <section>
         <h4>Access Token Verification Request</h4>
 
-        <p>If a resource server needs to verify that an access token is valid, it MUST make a GET request to the token endpoint containing an HTTP <code>Authorization</code> header with the Bearer Token according to [[!RFC6750]]. Note that the request to the endpoint will not contain any user-identifying information, so the resource server (e.g. Micropub endpoint) will need to know via out-of-band methods which token endpoint is in use.</p>
+        <p>If a resource server needs to verify that an access token is valid, it may do so using Token Introspection. IndieAuth extends OAuth 2.0 Token Introspection [[!RFC7662]] by defining the following:</p>
+      <ul>
+        <li>The introspection endpoint is the same as the token endpoint.</li>
+        <li>The introspection response MUST include an additional parameter, <code>me</code>.</li>
+      </ul>
+	<p>Note that the request to the endpoint will not contain any user-identifying information, so the resource server (e.g. Micropub endpoint) will need to know via out-of-band methods which token endpoint is in use.</p>
+	<p>The resource server SHOULD make a POST request to the token endpoint containing the bearer token in a 'token' parameter, which will generate a token verification response. The introspection endpoint MAY accept other OPTIONAL parameters to provide further context to the query.</p>
 
+          <pre class="example nohighlight"><?= htmlspecialchars(
+  'POST https://example.org/token
+  Content-type: application/x-www-form-urlencoded
+  Accept: application/json
+
+  token=xxxxxxxx
+  ') ?></pre>
+
+	<p>Alternatively, the resource server MAY make a GET request to the token endpoint containing an HTTP <code>Authorization</code> header with the Bearer Token according to [[!RFC6750]], but GET may not be supported by all token endpoints.</p>
         <pre class="example nohighlight">GET https://example.org/token
   Authorization: Bearer xxxxxxxx
   Accept: application/json</pre>
@@ -754,6 +769,9 @@ Content-Type: application/json
           <li><code>me</code> - The profile URL of the user corresponding to this token</li>
           <li><code>client_id</code> - The client ID associated with this token</li>
           <li><code>scope</code> - A space-separated list of scopes associated with this token</li>
+	  <li><code>active</code> - Boolean indicator of whether or not the presented token is currently active
+	  <li><code>exp</code> - (optional) Integer timestamp, measured in the number of seconds since January 1 1970 UTC, indicating when this token will expire</li>
+	  <li><code>iat</code> - (optional) Integer timestamp, measured in the number of seconds since January 1 1970 UTC, indicating when this token was originally issued</li>
         </ul>
 
         <pre class="example nohighlight">HTTP/1.1 200 OK
@@ -767,7 +785,7 @@ Content-Type: application/json
 
         <p>Specific implementations MAY include additional parameters as top-level JSON properties. Clients SHOULD ignore parameters they don't recognize.</p>
 
-        <p>If the token is not valid, the endpoint MUST return an appropriate HTTP 400, 401 or 403 response. The response body is not significant.</p>
+        <p>If the token is not valid, the endpoint still MUST return a 200 Response, with the only parameter being active(with its value set to "false"). The response SHOULD NOT include any additional information about an inactive token, including why the token is inactive.</p>
       </section>
     </section>
 

--- a/public/source/index.php
+++ b/public/source/index.php
@@ -772,9 +772,12 @@ Content-Type: application/json
   Content-Type: application/json
 
   {
+  "active": "true",
   "me": "https://user.example.net/",
   "client_id": https://app.example.com/",
   "scope": "create update delete"
+  "exp": "1632443647",
+  "iat": "1632443147"
   }</pre>
 
         <p>Specific implementations MAY include additional parameters as top-level JSON properties. Clients SHOULD ignore parameters they don't recognize.</p>


### PR DESCRIPTION
As per the proposal at the 2021 Popup, this extends the token verification response to match the token introspection endpoint parameters, and extends the request to support the POST method used in that extension. It does not remove GET, but retains it as an alternative, but aligns the response to same. It also changes trhe response to an invalid token to a 200 in line with the spec.

Closes #33.