### PR TITLE
Introduce Server Metadata and Iss Parameter

### DIFF
--- a/public/source/index.php
+++ b/public/source/index.php
@@ -272,11 +272,11 @@
               <li><code>authorization_endpoint</code> - The Authorization Endpoint</li>
               <li><code>token_endpoint</code> - The Token Endpoint</li>
 	      <li><code>scopes_supported</code> (recommended) - JSON Array containing scope values supported. Servers MAY choose not to advertise some supported scope values even when this parameter is used.</li>
-	      <li><code>response_types_supported</code> (optional) - JSON Array containing the response_type values supported. This differs from [RFC8414] in that this parameter is OPTIONAL and that, if omitted, the default is <code>code</code></li>
-	      <li><code>grant_types_supported</code> (optional) - JSON Array containing grant type values supported. If omitted, the default value differs from [RFC8414] and is <code>authorization_code</code></li>
-	      <li><code>service_documentation</code> (optional) - URL of a page containing human-readable information for developers.
-	      <li><code>code_challenge_methods_supported</code> - JSON Array containing the methods supported for PKCE. This parameter differs from [RFC8414] in that it is not optional as PKCE is REQUIRED.</li>
-	      <li><code>authorization_response_iss_parameter_supported</code> (optional) - Boolean parameter indicating whether the authorization server provides the <code>iss</code> parameter. If omitted, the default value is false. As this parameter is REQUIRED, this is provided for compatibility with OAuth 2.0 servers implementing the parameter.</li>
+              <li><code>response_types_supported</code> (optional) - JSON Array containing the response_type values supported. This differs from [RFC8414] in that this parameter is OPTIONAL and that, if omitted, the default is <code>code</code></li>
+              <li><code>grant_types_supported</code> (optional) - JSON Array containing grant type values supported. If omitted, the default value differs from [RFC8414] and is <code>authorization_code</code></li>
+              <li><code>service_documentation</code> (optional) - URL of a page containing human-readable information that developers might need to know when using the server. This might be a link to the IndieAuth spec or something more personal to your implementation.
+              <li><code>code_challenge_methods_supported</code> - JSON Array containing the methods supported for PKCE. This parameter differs from [RFC8414] in that it is not optional as PKCE is REQUIRED.</li>
+              <li><code>authorization_response_iss_parameter_supported</code> (optional) - Boolean parameter indicating whether the authorization server provides the <code>iss</code> parameter. If omitted, the default value is false. As this parameter is REQUIRED, this is provided for compatibility with OAuth 2.0 servers implementing the parameter.</li>
             </ul>
 
         <pre class="example nohighlight">HTTP/1.1 200 OK
@@ -473,7 +473,6 @@ Link: <https://example.org/token>; rel="token_endpoint"
             <li><code>iss</code> - The issuer identifier for client validation.</li>
           </ul>
 
-
           <pre class="example nohighlight"><?= htmlspecialchars(
   'HTTP/1.1 302 Found
   Location: https://app.example.com/redirect?code=xxxxxxxx&
@@ -484,7 +483,7 @@ Link: <https://example.org/token>; rel="token_endpoint"
 	  
 	  <ul>
 	    <li>That the <code>state</code> parameter in the request is valid and matches the state parameter that it initially created, in order to prevent CSRF attacks. The state value can also store session information to enable development of clients that cannot store data themselves.</li>
-	    <li>That the <code>iss</code> parameter in the request is valid and matches the issuer parameter provided by the Server Metadata endpoint during Discovery as outlined in <a href="https://www.ietf.org/archive/id/draft-ietf-oauth-iss-auth-resp-02.html">OAuth 2.0 Authorization Server Issuer Identification]</a>. Clients MUST compare the parameters using simple string comparison. If the value does not match the expected issuer identifier, clients MUST reject the authorization response and MUST NOT proceed with the authorization grant. For error responses, clients MUST NOT assume that the error originates from the intended authorization server. </li>
+	    <li>That the <code>iss</code> parameter in the request is valid and matches the issuer parameter provided by the Server Metadata endpoint during Discovery as outlined in <a href="https://www.ietf.org/archive/id/draft-ietf-oauth-iss-auth-resp-02.html">OAuth 2.0 Authorization Server Issuer Identification</a>. Clients MUST compare the parameters using simple string comparison. If the value does not match the expected issuer identifier, clients MUST reject the authorization response and MUST NOT proceed with the authorization grant. For error responses, clients MUST NOT assume that the error originates from the intended authorization server. </li>
 	  </ul>
 
           <p>See OAuth 2.0 [[!RFC6749]] <a href="https://tools.ietf.org/html/rfc6749#section-4.1.2.1">Section 4.1.2.1</a> for how to indicate errors and other failures to the user and client.</p>

--- a/public/source/index.php
+++ b/public/source/index.php
@@ -254,24 +254,24 @@
 
         <p>Clients MUST check for an HTTP <code>Link</code> header [[!RFC8288]] with the appropriate <code>rel</code> value. If the content type of the document is HTML, then the client MUST check for an HTML <code>&lt;link&gt;</code> element with the appropriate <code>rel</code> value. If more than one of these is present, the first HTTP <code>Link</code> header takes precedence, followed by the first <code>&lt;link&gt;</code> element in document order.</p>
 
-        <p>The URL discovered MAY be relative URLs, in which case the client MUST resolve them relative to the current document URL according to [[!URL]].</p>
+        <p>The URLs discovered MAY be relative URLs, in which case the client MUST resolve them relative to the current document URL according to [[!URL]].</p>
 
         <p>Clients MAY initially make an HTTP HEAD request [[!RFC7231]] to follow redirects and check for the <code>Link</code> header before making a GET request.</p>
 
-	<p>In the event there is no <code>indieauth-metadata</code> URL provided, for compatibility with previous revisions of IndieAuth, the client needs to discover the user's <code>authorization_endpoint</code>, and optionally <code>token_endpoint</code> if the client needs an access token.</p>
+        <p>In the event there is no <code>indieauth-metadata</code> URL provided, for compatibility with previous revisions of IndieAuth, the client needs to discover the user's <code>authorization_endpoint</code>, and optionally <code>token_endpoint</code> if the client needs an access token.</p>
 
          <section>
             <h4>IndieAuth Server Metadata</h4>
 
-	    <p>IndieAuth metadata adopts OAuth 2.0 Authorization Server Metadata[RFC8414], with the notable difference that usage of .well-known is RECOMMENDED, for compatibility with other OAuth2.0 implementation, as per Defining Well-Known Uniform Resource Identifiers[RFC5875] but OPTIONAL as well as any differences outlined below.</p>
+            <p>IndieAuth metadata adopts OAuth 2.0 Authorization Server Metadata[RFC8414], with the notable difference that usage of .well-known is RECOMMENDED, for compatibility with other OAuth2.0 implementation, as per Defining Well-Known Uniform Resource Identifiers[RFC5875] but OPTIONAL as well as any differences outlined below.</p>
 
             <p>The metadata endpoint returns information about the server:</p>
 
             <ul>
-              <li><code>issuer</code> - The server's issuer identifier. The issuer identifier is a URL that uses the "https" scheme and has no query or fragment components. The identifier is the base URL of the authorization endpoint, e.g. for an authorization endpoint <code>https://example.com/auth</code>, <code>https://example.com/</code></li>
+              <li><code>issuer</code> - The server's issuer identifier. The issuer identifier is a URL that uses the "https" scheme and has no query or fragment components. The identifier is the base URL of the authorization endpoint, e.g. for an authorization endpoint <code>https://example.com/auth</code>, the issuer URL would be<code>https://example.com/</code>, or for an authorization endpoint of <code>https://example.com/wp-json/indieauth/1.0/token</code>, the issuer URL would be <code>https://example.com/wp-json/indieauth/1.0</code></li>
               <li><code>authorization_endpoint</code> - The Authorization Endpoint</li>
               <li><code>token_endpoint</code> - The Token Endpoint</li>
-	      <li><code>scopes_supported</code> (recommended) - JSON Array containing scope values supported. Servers MAY choose not to advertise some supported scope values even when this parameter is used.</li>
+              <li><code>scopes_supported</code> (recommended) - JSON Array containing scope values supported. Servers MAY choose not to advertise some supported scope values even when this parameter is used.</li>
               <li><code>response_types_supported</code> (optional) - JSON Array containing the response_type values supported. This differs from [RFC8414] in that this parameter is OPTIONAL and that, if omitted, the default is <code>code</code></li>
               <li><code>grant_types_supported</code> (optional) - JSON Array containing grant type values supported. If omitted, the default value differs from [RFC8414] and is <code>authorization_code</code></li>
               <li><code>service_documentation</code> (optional) - URL of a page containing human-readable information that developers might need to know when using the server. This might be a link to the IndieAuth spec or something more personal to your implementation.

--- a/public/source/index.php
+++ b/public/source/index.php
@@ -268,7 +268,7 @@
             <p>The metadata endpoint returns information about the server:</p>
 
             <ul>
-              <li><code>issuer</code> - The server's issuer identifier. The issuer identifier is a URL that uses the "https" scheme and has no query or fragment components. The identifier MUST be a prefix of the authorization endpoint, e.g. for an authorization endpoint <code>https://example.com/auth</code>, the issuer URL could be <code>https://example.com/</code>, or for an authorization endpoint of <code>https://example.com/wp-json/indieauth/1.0/token</code>, the issuer URL could be <code>https://example.com/wp-json/indieauth/1.0</code></li>
+              <li><code>issuer</code> - The server's issuer identifier. The issuer identifier is a URL that uses the "https" scheme and has no query or fragment components. The identifier MUST be a prefix of the <code>indieauth-metadata</code> endpoint, e.g. for an <code>indieauth-metadata</code> endpoint <code>https://example.com/.well-known</code>, the issuer URL could be <code>https://example.com/</code>, or for an authorization endpoint of <code>https://example.com/wp-json/indieauth/1.0/metadata</code>, the issuer URL could be <code>https://example.com/wp-json/indieauth/1.0</code></li>
               <li><code>authorization_endpoint</code> - The Authorization Endpoint</li>
               <li><code>token_endpoint</code> - The Token Endpoint</li>
               <li><code>scopes_supported</code> (recommended) - JSON Array containing scope values supported. Servers MAY choose not to advertise some supported scope values even when this parameter is used.</li>

--- a/public/source/index.php
+++ b/public/source/index.php
@@ -263,12 +263,12 @@
          <section>
             <h4>IndieAuth Server Metadata</h4>
 
-            <p>IndieAuth metadata adopts OAuth 2.0 Authorization Server Metadata[RFC8414], with the notable difference that discovery of the URL happens via the IndieAuth link relations rather than the <code>.well-known discovery</code> method specified by RFC8414. For compatibility with other OAuth2.0 implementation, use of the <code>.well-known</code> path as defined in RFC5875 is RECOMMENDED but optional.</p>
+            <p>IndieAuth metadata adopts OAuth 2.0 Authorization Server Metadata[RFC8414], with the notable difference that discovery of the URL happens via the IndieAuth link relation rather than the <code>.well-known discovery</code> method specified by RFC8414. For compatibility with other OAuth 2.0 implementations, use of the <code>.well-known</code> path as defined in RFC5875 is RECOMMENDED but optional.</p>
 
             <p>The metadata endpoint returns information about the server:</p>
 
             <ul>
-              <li><code>issuer</code> - The server's issuer identifier. The issuer identifier is a URL that uses the "https" scheme and has no query or fragment components. The identifier MUST be a prefix of the authorization endpoint, e.g. for an authorization endpoint <code>https://example.com/auth</code>, the issuer URL would be<code>https://example.com/</code>, or for an authorization endpoint of <code>https://example.com/wp-json/indieauth/1.0/token</code>, the issuer URL would be <code>https://example.com/wp-json/indieauth/1.0</code></li>
+              <li><code>issuer</code> - The server's issuer identifier. The issuer identifier is a URL that uses the "https" scheme and has no query or fragment components. The identifier MUST be a prefix of the authorization endpoint, e.g. for an authorization endpoint <code>https://example.com/auth</code>, the issuer URL could be <code>https://example.com/</code>, or for an authorization endpoint of <code>https://example.com/wp-json/indieauth/1.0/token</code>, the issuer URL could be <code>https://example.com/wp-json/indieauth/1.0</code></li>
               <li><code>authorization_endpoint</code> - The Authorization Endpoint</li>
               <li><code>token_endpoint</code> - The Token Endpoint</li>
               <li><code>scopes_supported</code> (recommended) - JSON Array containing scope values supported. Servers MAY choose not to advertise some supported scope values even when this parameter is used.</li>

--- a/public/source/index.php
+++ b/public/source/index.php
@@ -263,12 +263,12 @@
          <section>
             <h4>IndieAuth Server Metadata</h4>
 
-            <p>IndieAuth metadata adopts OAuth 2.0 Authorization Server Metadata[RFC8414], with the notable difference that usage of .well-known is RECOMMENDED, for compatibility with other OAuth2.0 implementation, as per Defining Well-Known Uniform Resource Identifiers[RFC5875] but OPTIONAL as well as any differences outlined below.</p>
+            <p>IndieAuth metadata adopts OAuth 2.0 Authorization Server Metadata[RFC8414], with the notable difference that discovery of the URL happens via the IndieAuth link relations rather than the <code>.well-known discovery</code> method specified by RFC8414. For compatibility with other OAuth2.0 implementation, use of the <code>.well-known</code> path as defined in RFC5875 is RECOMMENDED but optional.</p>
 
             <p>The metadata endpoint returns information about the server:</p>
 
             <ul>
-              <li><code>issuer</code> - The server's issuer identifier. The issuer identifier is a URL that uses the "https" scheme and has no query or fragment components. The identifier is the base URL of the authorization endpoint, e.g. for an authorization endpoint <code>https://example.com/auth</code>, the issuer URL would be<code>https://example.com/</code>, or for an authorization endpoint of <code>https://example.com/wp-json/indieauth/1.0/token</code>, the issuer URL would be <code>https://example.com/wp-json/indieauth/1.0</code></li>
+              <li><code>issuer</code> - The server's issuer identifier. The issuer identifier is a URL that uses the "https" scheme and has no query or fragment components. The identifier MUST be a prefix of the authorization endpoint, e.g. for an authorization endpoint <code>https://example.com/auth</code>, the issuer URL would be<code>https://example.com/</code>, or for an authorization endpoint of <code>https://example.com/wp-json/indieauth/1.0/token</code>, the issuer URL would be <code>https://example.com/wp-json/indieauth/1.0</code></li>
               <li><code>authorization_endpoint</code> - The Authorization Endpoint</li>
               <li><code>token_endpoint</code> - The Token Endpoint</li>
               <li><code>scopes_supported</code> (recommended) - JSON Array containing scope values supported. Servers MAY choose not to advertise some supported scope values even when this parameter is used.</li>


### PR DESCRIPTION
This covers #43 and #101. Added the Iss parameter requirement as part of this PR as the Issuer Identifier had to be defined in Metadata.

This defines the metadata endpoint, notes the fallback to the old way of doing things, and requires that the iss parameter be returned by the authorization response and be verified against the metadata endpoint issuer parameter.