### PR TITLE
Call out IP based client_id should not be fetched

### DIFF
--- a/public/source/index.php
+++ b/public/source/index.php
@@ -458,7 +458,7 @@ viewbox="0 0 1169 1010" style="width: 100%; height: auto;"
 
           <p>The client SHOULD provide the <code>me</code> query string parameter to the authorization endpoint, either the exact value the user entered, or the value after applying <a href="url-canonicalization">URL Canonicalization</a>.</p>
 
-          <p>The authorization endpoint SHOULD fetch the <code>client_id</code> URL to retrieve application information and the client's registered redirect URLs, see <a href="#client-information-discovery">Client Information Discovery</a> for more information.</p>
+          <p>The authorization endpoint SHOULD fetch the <code>client_id</code> URL to retrieve application information and the client's registered redirect URLs, see <a href="#client-information-discovery">Client Information Discovery</a> for more information. If the <code>client_id</code> contains the permitted IPv4 and IPv6 addresses <code>127.0.0.1</code> or <code>[::1]</code>, the authorization endpoint MUST NOT fetch the <code>client_id</code>.</p>
 
           <p>If the URL scheme, host or port of the <code>redirect_uri</code> in the request do not match that of the <code>client_id</code>, then the authorization endpoint SHOULD verify that the requested <code>redirect_uri</code> matches one of the <a href="#redirect-url">redirect URLs</a> published by the client, and SHOULD block the request from proceeding if not.</p>
 


### PR DESCRIPTION
> The IndieAuth specs says: "Additionally, host names MUST be domain names or a loopback interface and MUST NOT be IPv4 or IPv6 addresses except for IPv4 127.0.0.1 or IPv6 [::1]."

> And further down: "The authorization endpoint SHOULD fetch the client_id URL to retrieve application information [...]"

> Is that a good idea if it can point to 127.0.0.1 / localhost? Sounds like the start of scary things.

This is my attempt to fix that. Hope I picked the right place and words.