### PR TITLE
Clarified token response properties, updated examples

### DIFF
--- a/public/source/index.php
+++ b/public/source/index.php
@@ -616,7 +616,7 @@ Cache-Control: no-store
             <li><code>token_type</code> (required) — the string <code>Bearer</code>.</li>
             <li><code>access_token</code> (required) - the OAuth 2.0 Bearer Token [[!RFC6750]].</li>
             <li><code>me</code> (required) - the canonical user profile URL for the user this access token corresponds to.</li>
-            <li><code>scope</code> (required/optional) — the scope granted to the client app. Required if different from the requested scope, otherwise optional.
+            <li><code>scope</code> (required/optional) — the scope granted to the client app. Required if different from the requested scope, otherwise optional.</li>
             <li><code>profile</code> (optional) - the user's profile information as defined in <a href="#profile-information">Profile Information</a>.</li>
             <li><code>expires_in</code> (recommended) - The lifetime in seconds of the access token.</li>
             <li><code>refresh_token</code> (optional) - The refresh token, which can be used to obtain new access tokens as defined in <a href="#refresh-tokens">Refresh Tokens</a>.</li>


### PR DESCRIPTION
Added token_type and scope to the list of token response properties, with descriptions.

Added Cache-control: no-store headers to all relevant examples. Awaiting review about whether it’s required/recommended on the profile information response.

Would fix #116 and #117 